### PR TITLE
Change the location of the default editor

### DIFF
--- a/home_dir/dot_bash_profile
+++ b/home_dir/dot_bash_profile
@@ -12,8 +12,9 @@ fi
 
 # export EDITOR='rmate -w'
 # export EDITOR='/usr/local/bin/sublime -w'
-export EDITOR='/usr/bin/emacs -nw'
-export GIT_EDITOR='/usr/bin/emacs -nw'
+
+export EDITOR='/usr/local/bin/emacs -nw'
+export GIT_EDITOR='/usr/local/bin/emacs -nw'
 
 PATH=$PATH:$HOME/bin:/usr/local/lib
 


### PR DESCRIPTION
Not sure what caused the emacs location to change. May be because I installed everything with brew this time.